### PR TITLE
fix: Update GitHub query and authentication method to get all repos of user

### DIFF
--- a/Models/GithubApi.cs
+++ b/Models/GithubApi.cs
@@ -18,9 +18,9 @@ namespace Wox.Plugin.Devbox.Helpers
         | SecurityProtocolType.Tls12
         | SecurityProtocolType.Ssl3;
 
-      string url = $"https://api.github.com/users/{settings.GithubUserName}/repos";
+      string url = $"https://api.github.com/user/repos?sort=updated";
       HttpWebRequest request = WebRequest.Create(url) as HttpWebRequest;
-      request.Headers["Authorization"] = "token " + settings.ApiToken;
+      request.Headers["Authorization"] = $"token {settings.ApiToken}";
       request.ProtocolVersion = HttpVersion.Version10;
       request.Method = "GET";
       request.UserAgent = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727)";
@@ -37,7 +37,6 @@ namespace Wox.Plugin.Devbox.Helpers
           {
             filteredResultsList.Add(result);
           }
-
         }
         return filteredResultsList;
       }


### PR DESCRIPTION
* Updates the GitHub API call to match v3 documentation
* Updates the authentication method to use `Authentication` header due to previous method being deprecated